### PR TITLE
ci & backend: fix EC2 public IP assignment and env variable naming

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -31,13 +31,7 @@ jobs:
         # Assign a new public IPv4
         aws ec2 modify-network-interface-attribute \
           --network-interface-id $INTERFACE_ID \
-          --no-source-dest-check
-          
-        # Note: Using auto-assigned public IP for ENI
-        PUBLIC_IP=$(aws ec2 describe-instances \
-          --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
-          --query 'Reservations[0].Instances[0].PublicIpAddress' \
-          --output text)
+          --associate-public-ip-address
 
 
     - name: Kill all tmux sessions
@@ -145,7 +139,7 @@ jobs:
           --document-name "AWS-RunShellScript" \
           --parameters '{"commands":[
             "sudo -u ec2-user bash -c '\''cd /home/ec2-user/watch-together/backend && tmux new-session -d -s watch-together-backend'\''",
-            "sudo -u ec2-user bash -c '\''tmux send-keys -t watch-together-backend \"PORT=${{ secrets.BACKEND_PORT }} YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }} npm run start\" C-m'\''"
+            "sudo -u ec2-user bash -c '\''tmux send-keys -t watch-together-backend \"BACKEND_PORT=${{ secrets.BACKEND_PORT }} YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }} npm run start\" C-m'\''"
           ]}' \
           --comment "Start server in tmux" \
           --query 'Command.CommandId' \
@@ -183,5 +177,4 @@ jobs:
         # Unassign the public IP
         aws ec2 modify-network-interface-attribute \
           --network-interface-id $INTERFACE_ID \
-          --no-source-dest-check \
           --no-associate-public-ip-address

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -44,10 +44,10 @@ io.on("connection", (socket) => {
   registerChatEventHandlers(io, socket);
 });
 
-const PORT = process.env.PORT;
+const BACKEND_PORT = process.env.BACKEND_PORT;
 
-if (!PORT) {
-  throw new Error("PORT not set in production!");
+if (!BACKEND_PORT) {
+  throw new Error("BACKEND_PORT not set in production!");
 }
 
-httpServer.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+httpServer.listen(BACKEND_PORT, () => console.log(`Server running on port ${BACKEND_PORT}`));


### PR DESCRIPTION
- Corrected `modify-network-interface-attribute` to properly associate/disassociate public IPv4
- Updated tmux command to use `BACKEND_PORT` instead of `PORT` for consistency
- Renamed backend server env variable from `PORT` → `BACKEND_PORT`
- Updated server.ts to throw error if `BACKEND_PORT` is missing and listen on `BACKEND_PORT`