### PR TITLE
fix: redirect to a not-found page for stale or invalid room links

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "watch-together-frontend",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "watch-together-frontend",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "@fontsource/roboto": "^5.2.8",
         "@tailwindcss/line-clamp": "^0.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "watch-together-frontend",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/room/RoomNotFound.tsx
+++ b/frontend/src/components/room/RoomNotFound.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const REDIRECT_SECONDS = 5;
+
+export default function RoomNotFound() {
+  const navigate = useNavigate();
+  const [secondsLeft, setSecondsLeft] = useState(REDIRECT_SECONDS);
+
+  useEffect(() => {
+    const id = setInterval(() => setSecondsLeft(s => s - 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (secondsLeft <= 0) navigate("/", { replace: true });
+  }, [secondsLeft, navigate]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 gap-4 text-center">
+      <h1 className="text-2xl font-semibold">Room Not Found</h1>
+      <p className="text-gray-400">This room doesn't exist or has expired.</p>
+      <p className="text-gray-500 text-sm">Redirecting to home in {Math.max(secondsLeft, 0)}s...</p>
+      <button
+        className="bg-red-600 text-white font-medium px-6 py-3 rounded-lg shadow hover:bg-red-700 transition"
+        onClick={() => navigate("/", { replace: true })}
+      >
+        Go Home
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/RoomPage.tsx
+++ b/frontend/src/pages/RoomPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { useParams } from "react-router-dom";
 import SearchBar from "../components/room/SearchBar";
 import RoomInfo from "../components/room/RoomInfo";
+import RoomNotFound from "../components/room/RoomNotFound";
 import VideoPlayer from "../components/room/VideoPlayer";
 import YoutubeVideo from "../components/youtube/YoutubeVideo";
 import type ChatMessage from "../interfaces/ChatMessage";
@@ -9,12 +10,14 @@ import type BaseVideoInfo from "../interfaces/BaseVideoInfo";
 import type YoutubeVideoInfo from "../interfaces/YoutubeVideoInfo";
 import RoomManager from "../managers/RoomManager";
 import SidePanel from "../components/side-panel/SidePanel";
+import { checkRoomExists } from "../services/room";
 
 
 export default function RoomPage() {
   const params = useParams();
-  const roomId = params.roomId!;
+  const roomId = params.roomId;
   const roomManagerRef = useRef<RoomManager | null>(null);
+  const [roomStatus, setRoomStatus] = useState<"loading" | "found" | "not-found">("loading");
   const [url, setUrl] = useState("");
   const [videoInfo, setVideoInfo] = useState<BaseVideoInfo | undefined>();
   const [playlistVideos, setPlaylistVideos] = useState<string[]>([]);
@@ -28,7 +31,32 @@ export default function RoomPage() {
   const playlistVideoLengthRef = useRef(0);
 
   useEffect(() => {
-    if (!roomId) return;
+    setRoomStatus("loading");
+
+    if (!roomId) {
+      setRoomStatus("not-found");
+      return;
+    }
+
+    let cancelled = false;
+
+    const verifyRoom = async () => {
+      try {
+        const exists = await checkRoomExists(roomId);
+        if (!cancelled) setRoomStatus(exists ? "found" : "not-found");
+      } catch {
+        if (!cancelled) setRoomStatus("not-found");
+      }
+    };
+
+    verifyRoom();
+
+    return () => { cancelled = true; };
+  }, [roomId]);
+
+
+  useEffect(() => {
+    if (!roomId || roomStatus !== "found") return;
 
     const onVideoChanged = async () => {
       const info = await roomManagerRef.current?.fetchCurrentVideoInfo();
@@ -61,7 +89,7 @@ export default function RoomPage() {
     roomManagerRef.current = new RoomManager(roomId, onVideoChanged, updatePlaylistUI, updateChatUI);
 
     return () => roomManagerRef.current?.destroy();
-  }, [roomId]);
+  }, [roomId, roomStatus]);
 
 
   const queueVideo = () => {
@@ -83,6 +111,18 @@ export default function RoomPage() {
     roomManagerRef.current.sendChatMessage(msg);
   };
 
+
+  if (roomStatus === "loading") {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-gray-400">Loading room...</p>
+      </div>
+    );
+  }
+
+  if (roomStatus === "not-found" || !roomId) {
+    return <RoomNotFound />;
+  }
 
   return (
     <div className="w-full h-full flex">

--- a/frontend/src/services/room.ts
+++ b/frontend/src/services/room.ts
@@ -1,7 +1,12 @@
 export async function createRoom() {
-  const response = await fetch(`${import.meta.env.VITE_APP_BACKEND_URL}/v1/rooms/create-room`, { 
+  const response = await fetch(`${import.meta.env.VITE_APP_BACKEND_URL}/v1/rooms/create-room`, {
     method: "POST",
   });
   const data = await response.json();
   return data.roomId;
+}
+
+export async function checkRoomExists(roomId: string): Promise<boolean> {
+  const response = await fetch(`${import.meta.env.VITE_APP_BACKEND_URL}/v1/rooms/${roomId}`);
+  return response.ok;
 }


### PR DESCRIPTION
Add checkRoomExists to verify a room before rendering RoomPage, and introduce a RoomNotFound component that auto-redirects home after a countdown. RoomPage now tracks a loading/found/not-found status and defers RoomManager setup until the room is confirmed to exist.