### PR TITLE
style: make chat popover mobile-friendly and darken info/chat UI

### DIFF
--- a/frontend/src/components/chat/ChatButton.tsx
+++ b/frontend/src/components/chat/ChatButton.tsx
@@ -38,7 +38,7 @@ export default function ChatButton({ messages, notifications, clearNotifications
                 onClick={toggleOpen}
                 className={`relative p-2 rounded-full hover:bg-gray-100/10 cursor-pointer ${isOpen ? "bg-gray-100/10" : ""}`}
             >
-                <MessageSquareText className="w-5 h-5 text-gray-300" />
+                <MessageSquareText className="w-5 h-5 stroke-neutral-500" />
                 {notifications > 0 && (
                     <div className="min-w-5 h-5 p-1 flex justify-center items-center -top-1 -right-1 absolute rounded-full bg-red-500 text-xs">
                         {notifications}
@@ -47,7 +47,7 @@ export default function ChatButton({ messages, notifications, clearNotifications
             </button>
 
             {isOpen && (
-                <div className="absolute right-0 top-full mt-2 sm:w-96 w-72 h-128 bg-neutral-900 border-white/40 border-1 rounded-lg p-2 z-20">
+                <div className="fixed inset-x-4 top-20 mx-auto max-w-96 sm:absolute sm:inset-x-auto sm:right-0 sm:top-full sm:mt-2 sm:mx-0 sm:max-w-none sm:w-96 aspect-3/4 bg-neutral-900 border-white/40 border-1 rounded-lg p-2 shadow-lg z-10">
                     <Chat messages={messages} sendMessage={sendMessage} />
                 </div>
             )}

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -47,6 +47,6 @@ export default function ChatInput({ onSend }: ChatInputProps) {
             onKeyDown={handleKeyDown}
             placeholder="Type a message..."
             rows={2}
-            className="w-full bg-white rounded-sm resize-none text-black p-1" />
+            className="w-full bg-neutral-600 rounded-sm resize-none text-white p-1" />
     );
 }

--- a/frontend/src/components/playlist/PlaylistVideo.tsx
+++ b/frontend/src/components/playlist/PlaylistVideo.tsx
@@ -22,7 +22,7 @@ interface PlaylistVideoData {
 function PlaylistVideoThumbnail({ thumbnail }: { thumbnail: string }) {
     return (
         <div className="aspect-video flex-shrink-0">
-            <img className="w-full h-full object-cover rounded-md" src={thumbnail || undefined} />
+            <img className="aspect-video h-full object-cover rounded-lg" src={thumbnail || undefined} />
         </div>
     );
 }

--- a/frontend/src/components/room/RoomInfo.tsx
+++ b/frontend/src/components/room/RoomInfo.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Info } from "lucide-react";
+import useClickOutside from "../../hooks/useClickOutside";
 
 
 /**
@@ -58,6 +59,10 @@ export default function RoomInfo({ roomId }: { roomId: string }) {
   // State for backend version
   const [backendVersion, setBackendVersion] = useState<string | null>(null);
 
+  const containerRef = useRef<HTMLButtonElement | null>(null);
+
+  useClickOutside(containerRef, () => setShow(false), show);
+
 
   // Ping backend every 5 seconds to measure latency
   useEffect(() => {
@@ -109,16 +114,17 @@ export default function RoomInfo({ roomId }: { roomId: string }) {
     <div className="relative">
       {/* Info Button */}
       <button
-        className="p-2 rounded-full hover:bg-gray-100"
+        ref={containerRef}
+        className="p-2 rounded-full hover:bg-gray-100/10"
         onClick={() => setShow((s) => !s)}
       >
-        <Info className="w-5 h-5 text-gray-600" />
+        <Info className="w-5 h-5 stroke-neutral-500" />
       </button>
 
       {/* Info Box */}
       {show && (
-        <div className="absolute left-0 mt-2 ml-2 w-56 p-4 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
-          <div className="text-sm text-gray-700">
+        <div className="absolute left-0 mt-2 ml-2 w-56 p-4 bg-neutral-900 border border-white/40 rounded-lg shadow-lg z-10">
+          <div className="text-sm text-neutral-300">
 
             {/* Room ID and Copy Button */}
             <p className="font-semibold">Room:</p>


### PR DESCRIPTION
Make the chat popover responsive — fixed and centered with a max width below sm, anchored to the button at sm+ — and switch its trigger icon to stroke-neutral-500. Recolor ChatInput to a dark textarea, fix PlaylistVideoThumbnail's aspect ratio/corner radius, and restyle RoomInfo's popover with a dark background plus a useClickOutside-driven close behavior matching ChatButton's.